### PR TITLE
Query `task_deposit`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fake-timeout",
+  "name": "croncat-indexer-query",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "fake-timeout",
+      "name": "croncat-indexer-query",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,9 @@ app.get('/tasks', async (req, res) => {
     res.status(200).send()
 })
 
-app.get('/tasks/:taskHash/deposits', async (req, res) => {
+// Get deposits by task hash 
+// Default denom is "ujunox"
+app.get('/tasks/:taskHash/deposits/:denom?', async (req, res) => {
     try {
         let results = await taskDepositByHash(req.params)
         res.status(!results ? 400 : 200).send(results)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors'
 import {config} from "dotenv"
 import knex from "knex";
 import {txs} from "./queries/tx";
+import { taskDepositByHash } from './queries/tasks';
 config({ path: '.env' })
 const app = express()
 
@@ -51,6 +52,16 @@ app.get('/agents', async (req, res) => {
 app.get('/tasks', async (req, res) => {
     console.log("list all tasks…")
     res.status(200).send()
+})
+
+app.get('/tasks/:taskHash/deposits', async (req, res) => {
+    try {
+        let results = await taskDepositByHash(req.params)
+        res.status(!results ? 400 : 200).send(results)
+    } catch (err) {
+        console.warn('Error hitting task deposit', err, req.params)
+        res.status(400).send({error: err})
+    }
 })
 
 app.get('/config', async (req, res) => {

--- a/src/queries/tasks.ts
+++ b/src/queries/tasks.ts
@@ -1,0 +1,14 @@
+import {db} from "../index";
+
+export const taskDepositByHash = async (params) => {
+    const hash = params.taskHash
+    console.log('getting deposits for task with hash', hash)
+    const res = await db.select({
+        x: 'fk_task_id',
+        y: 'amount'
+    }).from('js_task_deposits')
+        .innerJoin('js_tasks', 'js_task_deposits.fk_task_id', 'js_tasks.id')
+        .where('hash', hash)
+    console.log(`Total rows: ${res.length}`)
+    return res
+}

--- a/src/queries/tasks.ts
+++ b/src/queries/tasks.ts
@@ -2,13 +2,17 @@ import {db} from "../index";
 
 export const taskDepositByHash = async (params) => {
     const hash = params.taskHash
-    console.log('getting deposits for task with hash', hash)
+    const denom = params.denom || "ujunox"
+    console.log('getting deposits for task by hash ' + hash + ' with denom ' + denom)
     const res = await db.select({
         x: 'fk_task_id',
         y: 'amount'
     }).from('js_task_deposits')
         .innerJoin('js_tasks', 'js_task_deposits.fk_task_id', 'js_tasks.id')
-        .where('hash', hash)
+        .where({
+            'hash': hash,
+            'denom': denom
+        })
     console.log(`Total rows: ${res.length}`)
     return res
 }


### PR DESCRIPTION
Close #1

I made the ExpressJS route to be 
```
/tasks/:taskHash/deposits/:denom?
```
because we would probably want to see balances with the same denom. Let me know, if it'd better to delete `:denom?` and query by all coins.
If not specified, the default denom is ujunox.
