### PR TITLE
Query agent balances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors'
 import {config} from "dotenv"
 import knex from "knex";
 import {txs} from "./queries/tx";
+import { agentBalances } from './queries/agents';
 config({ path: '.env' })
 const app = express()
 
@@ -46,6 +47,16 @@ export const db = getDb()
 app.get('/agents', async (req, res) => {
     console.log("list all agents…")
     res.status(200).send()
+})
+
+app.get('/agent/:agentAddress', async (req, res) => {
+    try {
+        let results = await agentBalances(req.params)
+        res.status(!results ? 400 : 200).send(results)
+    } catch (err) {
+        console.warn('Error getting agent balances', err, req.params)
+        res.status(400).send({error: err})
+    }
 })
 
 app.get('/tasks', async (req, res) => {

--- a/src/queries/agents.ts
+++ b/src/queries/agents.ts
@@ -1,0 +1,31 @@
+import {db} from "../index";
+
+export const agentBalances = async (params) => {
+    let agentId = params.agentAddress
+    console.log('getting balances for agent', agentId)
+
+    const protocol = await db.select({
+        x: 'js_agent_balances.fk_agent_id',
+        y: 'js_agent_balances.amount',
+    }).from('js_agents')
+        .innerJoin('js_agent_balances', 'js_agent_balances.fk_agent_id', 'js_agents.id')
+        .where({
+            'js_agents.address': agentId,
+            'type': 'protocol',
+            'denom': 'ujunox'
+        })
+    const manager = await db.select({
+        x: 'js_agent_balances.fk_agent_id',
+        y: 'js_agent_balances.amount',
+    }).from('js_agents')
+        .innerJoin('js_agent_balances', 'js_agent_balances.fk_agent_id', 'js_agents.id')
+        .where({
+            'js_agents.address': agentId,
+            'type': 'manager-state',
+            'denom': 'ujunox'
+        })
+
+    console.log(`Total protocol balances: ${protocol.length}`)
+    console.log(`Total manager-state balances: ${manager.length}`)
+    return {'manager-state': manager, 'protocol': protocol}
+}


### PR DESCRIPTION
Closes #3.

Added a new query for agent balances (for now in ujunox only), the result contains two vectors (contract balances and agent's own balances).
For example, it may look like this:
```
{
    "manager-state": [
        {
            "x": "1",
            "y": "14046480"
        },
        {
            "x": "2",
            "y": "14146812"
        },
        {
            "x": "3",
            "y": "14096646"
        }
    ],
    "protocol": [
        {
            "x": "1",
            "y": "5200502"
        },
        {
            "x": "2",
            "y": "5109110"
        },
        {
            "x": "3",
            "y": "5154806"
        }
    ]
}
```
with `x` being `fk_agent_id`, `y` - balance.
